### PR TITLE
Add persistent memory notes

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -271,6 +271,7 @@ def get_parser(default_config_files, git_root):
     default_chat_history_file = (
         os.path.join(git_root, ".aider.chat.history.md") if git_root else ".aider.chat.history.md"
     )
+    default_memory_file = os.path.join(git_root, ".aider/memory.md") if git_root else ".aider/memory.md"
     group.add_argument(
         "--input-history-file",
         metavar="INPUT_HISTORY_FILE",
@@ -282,6 +283,12 @@ def get_parser(default_config_files, git_root):
         metavar="CHAT_HISTORY_FILE",
         default=default_chat_history_file,
         help=f"Specify the chat history file (default: {default_chat_history_file})",
+    ).complete = shtab.FILE
+    group.add_argument(
+        "--memory-file",
+        metavar="MEMORY_FILE",
+        default=default_memory_file,
+        help=f"Specify the persistent memory file (default: {default_memory_file})",
     ).complete = shtab.FILE
     group.add_argument(
         "--restore-chat-history",

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -335,6 +335,7 @@ class Coder:
         file_watcher=None,
         auto_copy_context=False,
         auto_accept_architect=True,
+        memory=None,
     ):
         # Fill in a dummy Analytics if needed, but it is never .enable()'d
         self.analytics = analytics if analytics is not None else Analytics()
@@ -348,6 +349,7 @@ class Coder:
 
         self.auto_copy_context = auto_copy_context
         self.auto_accept_architect = auto_accept_architect
+        self.memory = memory
 
         self.ignore_mentions = ignore_mentions
         if not self.ignore_mentions:
@@ -1258,12 +1260,21 @@ class Coder:
 
         chunks = ChatChunks()
 
+        memory_txt = self.memory.content.strip() if getattr(self, "memory", None) else ""
+
         if self.main_model.use_system_prompt:
-            chunks.system = [
-                dict(role="system", content=main_sys),
-            ]
+            chunks.system = []
+            if memory_txt:
+                chunks.system.append(dict(role="system", content=memory_txt))
+            chunks.system.append(dict(role="system", content=main_sys))
         else:
-            chunks.system = [
+            chunks.system = []
+            if memory_txt:
+                chunks.system += [
+                    dict(role="user", content=memory_txt),
+                    dict(role="assistant", content="Ok."),
+                ]
+            chunks.system += [
                 dict(role="user", content=main_sys),
                 dict(role="assistant", content="Ok."),
             ]

--- a/aider/main.py
+++ b/aider/main.py
@@ -28,6 +28,7 @@ from aider.copypaste import ClipboardWatcher
 from aider.deprecated import handle_deprecated_model_args
 from aider.format_settings import format_settings, scrub_sensitive_info
 from aider.history import ChatSummary
+from aider.memory import Memory
 from aider.io import InputOutput
 from aider.llm import litellm  # noqa: F401; properly init litellm on launch
 from aider.models import ModelSettings
@@ -945,6 +946,12 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         args.max_chat_history_tokens or main_model.max_chat_history_tokens,
     )
 
+    memory = Memory(
+        args.memory_file,
+        summarizer=summarizer,
+        io=io,
+    )
+
     if args.cache_prompts and args.map_refresh == "auto":
         args.map_refresh = "files"
 
@@ -996,6 +1003,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             detect_urls=args.detect_urls,
             auto_copy_context=args.copy_paste,
             auto_accept_architect=args.auto_accept_architect,
+            memory=memory,
         )
     except UnknownEditFormat as err:
         io.tool_error(str(err))

--- a/aider/memory.py
+++ b/aider/memory.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from aider.io import InputOutput
+from aider.history import ChatSummary
+
+
+class Memory:
+    def __init__(self, path, summarizer=None, io=None):
+        self.path = Path(path)
+        self.io = io or InputOutput()
+        self.summarizer = summarizer
+        self.content = self.load() or ""
+
+    def load(self):
+        if self.path.exists():
+            return self.io.read_text(self.path) or ""
+        return ""
+
+    def save(self, text):
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.io.write_text(self.path, text)
+        self.content = text
+
+    def append(self, text):
+        if not text.endswith("\n"):
+            text += "\n"
+        self.save(self.content + text)
+
+    def summarize(self):
+        if not self.summarizer or not self.content.strip():
+            return self.content
+        messages = [dict(role="user", content=self.content)]
+        try:
+            summary_msgs = self.summarizer.summarize_all(messages)
+        except Exception:
+            return self.content
+        summary = summary_msgs[0]["content"] if summary_msgs else self.content
+        self.save(summary)
+        return summary

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,14 @@
+# Persistent Memory
+
+Aider can keep running notes for a project. Notes are stored in a markdown file
+and automatically loaded at startup. The contents of this file are prepended to
+the initial system prompts so the assistant can remember important details about
+your code base.
+
+Use `--memory-file PATH` to choose the location of the file. By default the file
+`/.aider/memory.md` is placed in the root of your git repository (or the current
+directory if no repo is found).
+
+Within a chat session you can update the notes by appending text or asking the
+model to summarize them. Call `Memory.append(text)` to add new information and
+`Memory.summarize()` to condense the file using the chat summarizer.


### PR DESCRIPTION
## Summary
- add `Memory` for keeping conversation notes across runs
- load memory on startup and prepend to system prompts
- allow custom memory file via `--memory-file`
- document memory usage

## Testing
- `pytest -q`